### PR TITLE
Makefile: allow $(CFLAGS), $(LDFLAGS) override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 TQFTPSERV := tqftpserv
 
-CFLAGS := -Wall -g -O2
-LDFLAGS := -lqrtr
-
+CFLAGS += -Wall -g -O2
+LDFLAGS += -lqrtr
 prefix ?= /usr/local
+
 bindir := $(prefix)/bin
 servicedir := $(prefix)/lib/systemd/system
 


### PR DESCRIPTION
The caller might have specified `CFLAGS` or `LDFLAGS`. Let's respect those.

See https://github.com/andersson/rmtfs/commit/5eb67a1fb5a5238f3d560b38505b891285eb3c45 for something similar already done on `rmtfs` previously.